### PR TITLE
serve コマンドで処理時間を表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## main
 
+- [ADD] `serve` コマンドで初回ビルドおよび再ビルド時に処理時間を表示
 - [FIX] `serve` コマンドで `ls` 実行時にビルドが誤って走る問題を修正
   - `notify-debouncer-mini` から `notify-debouncer-full` に移行し、`EventKind::Access` を除外するようにした
   - [#46](https://github.com/veltiosoft/vss/pull/46)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,7 +2206,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vss"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/src/subcommand_serve.rs
+++ b/src/subcommand_serve.rs
@@ -12,7 +12,7 @@ use std::{
     net::SocketAddr,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tower_http::services::ServeDir;
 
@@ -62,8 +62,11 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
 async fn run_serve(config_path: &Path, port: u16) -> Result<()> {
     // 初回ビルド
     println!("[INFO] Running initial build...");
+    let start = Instant::now();
     subcommand_build::run_build(config_path)?;
+    let duration = start.elapsed();
     println!("[INFO] Initial build completed");
+    println!("build finished in {} ms", duration.as_millis());
 
     // 設定を読み込んで dist ディレクトリを取得
     let dist_dir = get_dist_dir(config_path)?;
@@ -145,10 +148,13 @@ fn watch_files(config_path: &Path, _rebuild_flag: Arc<Mutex<bool>>) -> Result<()
 
                 if should_rebuild {
                     println!("[INFO] File changed, rebuilding...");
+                    let start = std::time::Instant::now();
                     if let Err(e) = subcommand_build::run_build(&config_path_clone) {
                         eprintln!("[ERROR] Rebuild failed: {:#}", e);
                     } else {
+                        let duration = start.elapsed();
                         println!("[INFO] Rebuild completed");
+                        println!("build finished in {} ms", duration.as_millis());
                     }
                 }
             }

--- a/src/subcommand_serve.rs
+++ b/src/subcommand_serve.rs
@@ -18,6 +18,13 @@ use tower_http::services::ServeDir;
 
 use crate::subcommand_build;
 
+/// ビルドを実行し、処理時間を返す
+fn run_build_with_timing(config_path: &Path) -> Result<Duration> {
+    let start = Instant::now();
+    subcommand_build::run_build(config_path)?;
+    Ok(start.elapsed())
+}
+
 /// serve コマンドのエントリポイント
 pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
     let config: Option<PathBuf> = noargs::opt("config")
@@ -62,9 +69,7 @@ pub fn run(mut args: noargs::RawArgs) -> noargs::Result<()> {
 async fn run_serve(config_path: &Path, port: u16) -> Result<()> {
     // 初回ビルド
     println!("[INFO] Running initial build...");
-    let start = Instant::now();
-    subcommand_build::run_build(config_path)?;
-    let duration = start.elapsed();
+    let duration = run_build_with_timing(config_path)?;
     println!("[INFO] Initial build completed");
     println!("build finished in {} ms", duration.as_millis());
 
@@ -148,13 +153,14 @@ fn watch_files(config_path: &Path, _rebuild_flag: Arc<Mutex<bool>>) -> Result<()
 
                 if should_rebuild {
                     println!("[INFO] File changed, rebuilding...");
-                    let start = std::time::Instant::now();
-                    if let Err(e) = subcommand_build::run_build(&config_path_clone) {
-                        eprintln!("[ERROR] Rebuild failed: {:#}", e);
-                    } else {
-                        let duration = start.elapsed();
-                        println!("[INFO] Rebuild completed");
-                        println!("build finished in {} ms", duration.as_millis());
+                    match run_build_with_timing(&config_path_clone) {
+                        Ok(duration) => {
+                            println!("[INFO] Rebuild completed");
+                            println!("build finished in {} ms", duration.as_millis());
+                        }
+                        Err(e) => {
+                            eprintln!("[ERROR] Rebuild failed: {:#}", e);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- `serve` コマンドの初回ビルドと再ビルド（ファイル変更検知時）で処理時間を表示
- `build` コマンドと同じフォーマット「`build finished in {} ms`」を使用

## 出力例

```
[INFO] Running initial build...
[INFO] Initial build completed
build finished in 123 ms
[INFO] serving on http://localhost:8080

[INFO] File changed, rebuilding...
[INFO] Rebuild completed
build finished in 45 ms
```

## Test plan

- [ ] `cargo build` でビルド成功を確認
- [ ] `cargo run -- serve` を実行し、初回ビルドの処理時間が表示されることを確認
- [ ] ソースファイルを変更し、再ビルドの処理時間が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)